### PR TITLE
Fixed memory leak with pcre object

### DIFF
--- a/core/downloader/downloader.c
+++ b/core/downloader/downloader.c
@@ -14,7 +14,7 @@
 size_t save_data(void *ptr, size_t size, size_t nmemb, void *ss) {
   cs_task_t *save = (cs_task_t*)ss;
   size_t count = save->data->count;
-  size_t all = size * nmemb;
+  size_t all = (size * nmemb) + 1;
   
   char* buf = (char*) malloc(all);
   if(buf == NULL) 

--- a/core/utils/regex.c
+++ b/core/utils/regex.c
@@ -45,6 +45,8 @@ int regexAll(const char *regex, char *str, char **res, int num, int flag) {
     }
   } while( rc > 0 && index < num);
 
+  pcre_free(re);
+
   return index;
 }
 


### PR DESCRIPTION
The `pcre_compile` was leaking memory without following up with a call to `pcre_free`.  

From the [pcre](http://pcre.org/pcre.txt) docs:
>It is up to the caller to free the memory (via pcre_free) when it is no
       longer required.