### PR TITLE
Parse uri to components

### DIFF
--- a/core/includes/uriparser.h
+++ b/core/includes/uriparser.h
@@ -1,6 +1,25 @@
+typedef enum {
+  URI_SCHEME = 0,
+  URI_AUTH,
+  URI_HOST,
+  URI_PORT,
+  URI_PATH,
+  URI_QUERY,
+  URI_FRAGMENT
+} URIACTION;
 
 void
 joinall(char *, char **, int);
 
 char *
 join(char *, char*);
+
+char *
+uri_component(char *, URIACTION);
+  
+void
+rstrip(char *);
+
+void
+lstrip(char *);
+

--- a/core/utils/uriparser.c
+++ b/core/utils/uriparser.c
@@ -130,7 +130,7 @@ uri_component(char *adr, URIACTION action){
   size_t len = 0;
   int r ;
   
-  if (adr == NULL || strlen(adr) == 0) return uri;
+  if (adr == NULL || strlen(adr) == 0) return buffer;
   uri = uri_create_str(adr,NULL);
 
   switch(action){

--- a/core/utils/uriparser.c
+++ b/core/utils/uriparser.c
@@ -52,6 +52,26 @@ get_uri(URI *uri) {
   return buffer;
 }
 
+static int
+getcomponent(URI *uri, size_t (*fn)(URI *, char *, size_t), char **buffer, size_t *len){
+  size_t r;
+  char *p;
+
+  r = fn(uri,*buffer,*len);
+  if(r == (size_t)-1) return -1;
+  if(r > *len){
+    p = (char *) realloc(*buffer,r);
+    if(p == NULL) return -1;
+    *buffer = p;
+    *len = r;
+    r = fn(uri,*buffer,*len);
+    if(r == (size_t)-1) return -1;
+  }
+  if(r == 0) return -1;
+
+  return 1;
+}
+
 char *
 join(char *baseuri, char *reluri){
 
@@ -100,5 +120,60 @@ joinall(char *baseuri, char **uris, int size){
     uris[i] = NULL;
     uris[i] = parsed;
     parsed = NULL;
+  }
+}
+
+char *
+uri_component(char *adr, URIACTION action){
+  URI *uri = NULL;
+  char *buffer = NULL;
+  size_t len = 0;
+  int r ;
+  
+  if (adr == NULL || strlen(adr) == 0) return uri;
+  uri = uri_create_str(adr,NULL);
+
+  switch(action){
+  case URI_SCHEME:
+    if(getcomponent(uri,uri_scheme,&buffer,&len) == 1){
+      uri_destroy(uri);
+      return buffer;
+    }
+    
+  case URI_AUTH:
+    if(getcomponent(uri,uri_auth,&buffer,&len) == 1){
+      uri_destroy(uri);
+      return buffer;
+    }
+    
+  case URI_HOST:
+    if(getcomponent(uri,uri_host,&buffer,&len) == 1){
+      uri_destroy(uri);
+      return buffer;
+    }
+    
+  case URI_PORT:
+    if(getcomponent(uri,uri_port,&buffer,&len) == 1){
+      uri_destroy(uri);
+      return buffer;
+    }
+    
+  case URI_PATH:
+    if(getcomponent(uri,uri_path,&buffer,&len) == 1){
+      uri_destroy(uri);
+      return buffer;
+    }
+    
+  case URI_QUERY:
+    if(getcomponent(uri,uri_query,&buffer,&len) == 1){
+      uri_destroy(uri);
+      return buffer;
+    }
+    
+  case URI_FRAGMENT:
+    if(getcomponent(uri,uri_fragment,&buffer,&len) == 1){
+      uri_destroy(uri);
+      return buffer;
+    }
   }
 }


### PR DESCRIPTION
@xonce/cspider 

Added 

    char * uri_component(char *uri , URIACTION);

We can get following components from a uri:

    typedef enum {
      URI_SCHEME = 0,
      URI_AUTH,
      URI_HOST,
      URI_PORT,
      URI_PATH,
      URI_QUERY,
      URI_FRAGMENT
    } URIACTION;

Besides that, these two functions are available too :

    // they modify original buffer
    void rstrip(char *url);
    void lstrip(char *url);

