### PR TITLE
Using libuv to manager thread pool

### DIFF
--- a/core/downloader/downloader.c
+++ b/core/downloader/downloader.c
@@ -94,7 +94,6 @@ void work_done(uv_work_t *req, int status) {
     finally, free the task.
    */
   uv_rwlock_wrlock(cspider->lock);
-  cspider->download_thread--;
   cs_task_queue *q = removeTask(cspider->task_queue_doing, req->data);
   PANIC(q);
   

--- a/core/includes/spider.h
+++ b/core/includes/spider.h
@@ -8,9 +8,6 @@
 #include "cJSON.h"
 #include "uriparser.h"
 
-#define DOWNLOAD 1
-#define SAVE     0
-
 typedef struct site_struct {
   char *user_agent;//user agent
   char *proxy;// proxy address
@@ -33,12 +30,8 @@ struct cspider_struct {
   //
   void *process_user_data;
   void *save_user_data;
-  //Max thread number
-  int download_thread_max;
-  int pipeline_thread_max;
-  //current thread number
-  int download_thread;
-  int pipeline_thread;
+  //Thread pool's size
+  int threadpool_size;
   //lock
   uv_rwlock_t *lock;
   //data persistence lock
@@ -61,7 +54,7 @@ void cs_setopt_timeout(cspider_t *cspider, long timeout);
 void cs_setopt_logfile(cspider_t *cspider, FILE *log);
 void cs_setopt_process(cspider_t *cspider, void (*process)(cspider_t *, char *, char*, void*), void *user_data);
 void cs_setopt_save(cspider_t *cspider, void (*save)(void*, void*), void *user_data);
-void cs_setopt_threadnum(cspider_t *cspider, int flag, int number);
+void cs_setopt_threadnum(cspider_t *cspider, int number);
 int cs_run(cspider_t *cspider);
 
 #endif

--- a/core/pageProcesser/dataProcess.c
+++ b/core/pageProcesser/dataProcess.c
@@ -36,7 +36,6 @@ void datasave(uv_work_t *req, int status) {
   logger(0, "%s save finish.\n", ((cs_rawText_t*)req->data)->url, cspider);
   
   uv_rwlock_wrlock(cspider->lock);
-  cspider->pipeline_thread--;
   cs_rawText_queue *q = removeData(cspider->data_queue_doing, req->data);
   PANIC(q);
   

--- a/core/scheduler/watcher.c
+++ b/core/scheduler/watcher.c
@@ -5,16 +5,14 @@
   @handle : the uv_idle_t
 **/
 void watcher(uv_prepare_t *handle) {
+  printf("test !\n");
   cspider_t *cspider = (cspider_t*)handle->data;
   uv_rwlock_wrlock(cspider->lock);
   if (!isTaskQueueEmpty(cspider->task_queue)) {
     /*
       if there is task unhandled yet, start work thread
      */
-    if (cspider->download_thread <= cspider->download_thread_max) {
-      /*
-	when thread's number reach the max limit
-       */
+    
       cs_task_queue *rem = removeTask(cspider->task_queue, cspider->task_queue->next->task);
       PANIC(rem);
     
@@ -28,16 +26,13 @@ void watcher(uv_prepare_t *handle) {
       ptask->cspider = cspider;
       addTask(cspider->task_queue_doing, rem);
       uv_queue_work(cspider->loop, req, download, work_done);
-
-      //add thread's number
-      cspider->download_thread++;
-    }
+    
   }
   
   if (!isDataQueueEmpty(cspider->data_queue)) {
     //if there is data required to be processed,
     // start thread
-    if (cspider->pipeline_thread <= cspider->pipeline_thread_max) {
+    
       cs_rawText_queue *rem = removeData(cspider->data_queue, cspider->data_queue->next->data);
       PANIC(rem);
       	
@@ -53,8 +48,7 @@ void watcher(uv_prepare_t *handle) {
       
       addData(cspider->data_queue_doing, rem);
       uv_queue_work(cspider->loop, req, dataproc, datasave);
-      cspider->pipeline_thread++;
-    }
+    
   }
 
   if (!isTaskQueueEmpty(cspider->task_queue_doing) ||

--- a/core/scheduler/watcher.c
+++ b/core/scheduler/watcher.c
@@ -5,7 +5,6 @@
   @handle : the uv_idle_t
 **/
 void watcher(uv_prepare_t *handle) {
-  printf("test !\n");
   cspider_t *cspider = (cspider_t*)handle->data;
   uv_rwlock_wrlock(cspider->lock);
   if (!isTaskQueueEmpty(cspider->task_queue)) {

--- a/sample/github.c
+++ b/sample/github.c
@@ -75,10 +75,7 @@ int main() {
 	cs_setopt_save(spider, save, stdout);
 
 	// Number of downloader threads
-	cs_setopt_threadnum(spider, DOWNLOAD, 2);
-
-	// Number of persistency threads
-	cs_setopt_threadnum(spider, SAVE, 2);
+	cs_setopt_threadnum(spider, 10);
 
 	return cs_run(spider);
 

--- a/sample/main.c
+++ b/sample/main.c
@@ -31,8 +31,7 @@ int main() {
   cs_setopt_process(spider, p, NULL);
   cs_setopt_save(spider, s, stdout);
   //设置抓取线程数量，和数据持久化的线程数量
-  cs_setopt_threadnum(spider, DOWNLOAD, 2);
-  cs_setopt_threadnum(spider, SAVE, 2);
+  cs_setopt_threadnum(spider, 5);
   cs_setopt_logfile(spider, stdout);
 
   return cs_run(spider);


### PR DESCRIPTION
libuv provides a thread pool, and I use it here to manager download and process threads. The thread pool's size can be initialized by `setenv(UV_THREADPOOL_SIZE, "", 1);` . Before this, I have misunderstanded libuv's thread pool.